### PR TITLE
Impl template auto-selection

### DIFF
--- a/frontend/src/lib/components/generator/CompaniesPanel.svelte
+++ b/frontend/src/lib/components/generator/CompaniesPanel.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { CompaniesAPI } from '$lib/backend/api/companies';
 	import type { Company } from '$lib/backend/models/companies';
-	import Autocomplete from '@smui-extra/autocomplete';
 	import { onMount } from 'svelte';
 	import CircularLoader from '../common/CircularLoader.svelte';
 	import Panel from '../common/Panel.svelte';
 	import Snackbar from '../common/Snackbar.svelte';
+	import Select, { Option } from '@smui/select';
 
 	export let token: string;
 
@@ -14,9 +14,9 @@
 	const companiesApi = new CompaniesAPI(token);
 
 	export let selectedCompany: Company = {
-        company_id: "",
-        name: "",
-    };
+		company_id: '',
+		name: ''
+	};
 	let companies: Company[] = [];
 	let companiesLoading = false;
 
@@ -42,15 +42,11 @@
 	{#if companiesLoading}
 		<CircularLoader size="large" />
 	{:else}
-		<Autocomplete
-			label="Организация"
-			style="width: 100%;"
-			textfield$style="width: 100%;"
-			combobox
-			options={companies}
-			getOptionLabel={getCompanyLabel}
-			bind:value={selectedCompany.name}
-		/>
+		<Select label="Организация" bind:value={selectedCompany}>
+			{#each companies as company (company.company_id)}
+				<Option value={company}>{company.name}</Option>
+			{/each}
+		</Select>
 	{/if}
 </Panel>
 

--- a/frontend/src/routes/(authorized)/generator/+page.svelte
+++ b/frontend/src/routes/(authorized)/generator/+page.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div class="panels-container">
-	<OfferTplsPanel token={data.token} bind:selectedOfferTpl={offerTpl} />
+	<!-- <OfferTplsPanel token={data.token} bind:selectedOfferTpl={offerTpl} /> -->
 	<CompaniesPanel token={data.token} bind:selectedCompany={offerContext.company} />
 	<AgentsPanel token={data.token} bind:agent={offerContext.agent} />
 	<OfferDataPanel


### PR DESCRIPTION
As customer require, templates now selected by company and type, so templates selection menu is removed.

Templates now should have name in following format: company_id-type-0

I hope it is temporary trick and templates selection menu will be returned in future